### PR TITLE
Add support for internal section links

### DIFF
--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -153,19 +153,61 @@ function Math(el)
   return el
 end
 
+
+local function starts_with(str, start)
+   return str:sub(1, #start) == start
+end
+
+local function ends_with(str, ending)
+   return ending == "" or str:sub(-#ending) == ending
+end
+
+local function headerLink(input)
+  -- github style section link
+  return "#"..input:gsub(' ', '-')
+end
+
+
+local function insertLink(content, linkDescription)
+  local descriptionText = table.concat(linkDescription, "")
+
+  if string.find(descriptionText, '|') then
+    local target, desc = descriptionText:match("(.*)|(.*)")
+    table.insert(content, pandoc.Link(desc, headerLink(target)))
+  else
+    table.insert(content, pandoc.Link(descriptionText, headerLink(descriptionText)))
+  end
+end
+
 function Para(el)
   local content = {}
   local in_display_math = false
+  local in_section_link = false
+  local linkDescription = {}
   for _, item in pairs(el.content) do
     if item.t == 'Str'and item.text == "$$" then
       in_display_math = not in_display_math
+    elseif item.t == 'Str' and starts_with(item.text, '[[#') then
+      in_section_link = true
+      table.insert(linkDescription, string.sub(item.text, 4))
     else
       if in_display_math then
+        -- handle insides of math
         if item.t == 'RawInline' and item.format == 'tex' then
           local n = pandoc.Math('DisplayMath', '\n' .. item.text .. '\n')
           table.insert(content, Math(n))
         else
           table.insert(content, item)
+        end
+      elseif in_section_link then
+        -- handle insides of internal section link
+        if ends_with(item.text, ']]') then
+          table.insert(linkDescription, string.sub(item.text, 1, -3))
+          insertLink(content, linkDescription)
+          in_section_link = false
+          linkDescription = {}
+        else
+          table.insert(linkDescription, item.text)
         end
       else
         table.insert(content, item)

--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -153,15 +153,6 @@ function Math(el)
   return el
 end
 
-
-local function starts_with(str, start)
-   return str:sub(1, #start) == start
-end
-
-local function ends_with(str, ending)
-   return ending == "" or str:sub(-#ending) == ending
-end
-
 local function headerLink(input)
   -- github style section link
   return "#"..input:gsub(' ', '-')
@@ -215,11 +206,11 @@ function ProcessInternalLinks(elements)
   local linkDescription = {}
 
   for _, item in pairs(elements) do
-    if item.t == 'Str' and starts_with(item.text, '[[#') then
+    if item.t == 'Str' and Starts_with(item.text, '[[#') then
       in_section_link = true
       table.insert(linkDescription, string.sub(item.text, 4))
     elseif in_section_link then
-      if ends_with(item.text, ']]') then
+      if Ends_with(item.text, ']]') then
         table.insert(linkDescription, string.sub(item.text, 1, -3))
         insertLink(content, linkDescription)
         in_section_link = false

--- a/lua/polyfill.lua
+++ b/lua/polyfill.lua
@@ -43,3 +43,11 @@ os.exists = function(path)
     return code == 0
   end
 end
+
+function Starts_with(str, start)
+   return str:sub(1, #start) == start
+end
+
+function Ends_with(str, ending)
+   return ending == "" or str:sub(-#ending) == ending
+end

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -1,5 +1,6 @@
-import { exec as execSync, ExecException } from 'child_process';
 import os from 'os';
+import { exec as execSync, ExecException } from 'child_process';
+import { readFile } from 'fs/promises';
 
 
 export async function exec(cmd: string, options: { lineSeparator: '\n' | '\r\n' | '\r' }): Promise<string> {
@@ -21,4 +22,12 @@ export async function exec(cmd: string, options: { lineSeparator: '\n' | '\r\n' 
 }
 
 
-
+export const testConversion = async (name: String, filter: String) => {
+  process.chdir(module.path);
+  const input_file = `./markdowns/${name}.md`;
+  const expect_out = `./markdowns/${name}.out`;
+  const lua_script = `../lua/${filter}.lua`;
+  const pandoc = `pandoc -s -L ${lua_script}  -t native -f markdown "${input_file}"`;
+  const ret = await exec(pandoc, { lineSeparator: '\n'});
+  expect(ret).toBe(await readFile(expect_out, { encoding: 'utf-8', flag: 'r' }));
+}

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -27,7 +27,7 @@ export const testConversion = async (name: String, filter: String) => {
   const input_file = `./markdowns/${name}.md`;
   const expect_out = `./markdowns/${name}.out`;
   const lua_script = `../lua/${filter}.lua`;
-  const pandoc = `pandoc -s -L ${lua_script}  -t native -f markdown "${input_file}"`;
+  const pandoc = `pandoc -s -L ${lua_script}  -t native -f markdown "${input_file}" -o -`;
   const ret = await exec(pandoc, { lineSeparator: '\n'});
   expect(ret).toBe(await readFile(expect_out, { encoding: 'utf-8', flag: 'r' }));
 }

--- a/tests/internalLink.spec.ts
+++ b/tests/internalLink.spec.ts
@@ -1,0 +1,11 @@
+
+import { exec, testConversion } from './common';
+
+
+test('test basic internal link block parsing', async () => {
+  await testConversion('internal-link-basic', 'markdown')
+});
+
+test('test complex internal link block parsing', async () => {
+  await testConversion('internal-link-bullet', 'markdown')
+});

--- a/tests/internalLink.spec.ts
+++ b/tests/internalLink.spec.ts
@@ -9,3 +9,7 @@ test('test basic internal link block parsing', async () => {
 test('test complex internal link block parsing', async () => {
   await testConversion('internal-link-bullet', 'markdown')
 });
+
+test('test basic internal link with description', async () => {
+  await testConversion('internal-link-described', 'markdown')
+});

--- a/tests/markdowns/internal-link-basic.md
+++ b/tests/markdowns/internal-link-basic.md
@@ -1,0 +1,1 @@
+[[#Some complex section]]

--- a/tests/markdowns/internal-link-basic.out
+++ b/tests/markdowns/internal-link-basic.out
@@ -1,0 +1,14 @@
+Pandoc
+  Meta { unMeta = fromList [] }
+  [ Para
+      [ Link
+          ( "" , [] , [] )
+          [ Str "Some"
+          , Space
+          , Str "complex"
+          , Space
+          , Str "section"
+          ]
+          ( "#Some-complex-section" , "" )
+      ]
+  ]

--- a/tests/markdowns/internal-link-bullet.md
+++ b/tests/markdowns/internal-link-bullet.md
@@ -1,0 +1,3 @@
+- potato
+- [[#more complex vegetables]]
+- cucumber

--- a/tests/markdowns/internal-link-bullet.out
+++ b/tests/markdowns/internal-link-bullet.out
@@ -1,0 +1,19 @@
+Pandoc
+  Meta { unMeta = fromList [] }
+  [ BulletList
+      [ [ Plain [ Str "potato" ] ]
+      , [ Plain
+            [ Link
+                ( "" , [] , [] )
+                [ Str "more"
+                , Space
+                , Str "complex"
+                , Space
+                , Str "vegetables"
+                ]
+                ( "#more-complex-vegetables" , "" )
+            ]
+        ]
+      , [ Plain [ Str "cucumber" ] ]
+      ]
+  ]

--- a/tests/markdowns/internal-link-described.md
+++ b/tests/markdowns/internal-link-described.md
@@ -1,0 +1,1 @@
+[[#Some complex section|with custom description]]

--- a/tests/markdowns/internal-link-described.out
+++ b/tests/markdowns/internal-link-described.out
@@ -1,0 +1,14 @@
+Pandoc
+  Meta { unMeta = fromList [] }
+  [ Para
+      [ Link
+          ( "" , [] , [] )
+          [ Str "with"
+          , Space
+          , Str "custom"
+          , Space
+          , Str "description"
+          ]
+          ( "#Some-complex-section" , "" )
+      ]
+  ]

--- a/tests/mathBlock.spec.ts
+++ b/tests/mathBlock.spec.ts
@@ -1,14 +1,6 @@
-import { exec } from './common';
+import { exec, testConversion } from './common';
 import { readFile } from 'fs/promises';
 
-
 test('test math block parsing', async () => {
-  process.chdir(module.path);
-  const input_file = './markdowns/math-block.md';
-  const expect_out = './markdowns/math-block.out';
-  const lua_script = '../lua/math_block.lua';
-  const pandoc = `pandoc -s -L ${lua_script}  -t native -f markdown "${input_file}"`;
-  const ret = await exec(pandoc, { lineSeparator: '\n'});
-  // await writeFile('./out.txt', ret);
-  expect(ret).toBe(await readFile(expect_out, { encoding: 'utf-8', flag: 'r' }));
+  await testConversion('math-block', 'math_block')
 });


### PR DESCRIPTION
This commit adjusts the `markdown` lua filter for pandoc so that it convert the internal section links to github compatible format. For example, following conversions will be done:

- `[[#important section]]` converts to `[important section](#important-section)`
- `[[#other section|with description]]` converts to `[with description](#other-section)`