### PR TITLE
Require specific version of pandoc

### DIFF
--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -6,8 +6,8 @@ local url = require('url')
 local pandoc=pandoc
 local PANDOC_STATE=PANDOC_STATE
 
-PANDOC_VERSION:must_be_at_least '2.12'
-pandoc.path = require("pandoc.path")
+PANDOC_VERSION:must_be_at_least '2.17'
+
 local PATH = pandoc.path
 local doc_dir = nil
 local media_dir = nil

--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -6,7 +6,8 @@ local url = require('url')
 local pandoc=pandoc
 local PANDOC_STATE=PANDOC_STATE
 
-
+PANDOC_VERSION:must_be_at_least '2.12'
+pandoc.path = require("pandoc.path")
 local PATH = pandoc.path
 local doc_dir = nil
 local media_dir = nil


### PR DESCRIPTION
- The `pandoc.path` module that is [used to detect PATH](https://github.com/mokeyish/obsidian-enhancing-export/blob/43d28e96322fde1d5ecdcdd00291cfeaf4b33dca/lua/markdown.lua#L10) has been added in pandoc 2.12, but is not auto-loaded on startup until pandoc 2.16.1.
- The `PANDOC_WRITER_OPTIONS` (used [here](https://github.com/mokeyish/obsidian-enhancing-export/blob/43d28e96322fde1d5ecdcdd00291cfeaf4b33dca/lua/markdown.lua#L24) has been added in 2.17

This commit ensures that user-friendly message is printed instead of a vague 'attempt to index a nil value (local PATH)' error.

Solves #9 