### PR TITLE
🐛 Fix imgs with neurips template + export to .tex

### DIFF
--- a/src/export_templates.ts
+++ b/src/export_templates.ts
@@ -107,7 +107,7 @@ export default {
         options: [
           { name: 'None', value: null },
           { name: 'Dissertation', value: 'dissertation.tex' },
-          { name: 'Academic Paper', value: 'academic.tex' }]
+          { name: 'Academic Paper', value: 'neurips.tex' }]
       },
     },
     extension: '.latex',

--- a/textemplate/neurips.tex
+++ b/textemplate/neurips.tex
@@ -32,6 +32,21 @@
 \usepackage{nicefrac}       % compact symbols for 1/2, etc.
 \usepackage{microtype}      % microtypography
 \usepackage{xcolor}         % colors
+\usepackage{graphicx}
+
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\makeatother
+% Scale images if necessary, so that they will not overflow the page
+% margins by default, and it is still possible to overwrite the defaults
+% using explicit options in \includegraphics[width, height, ...]{}
+\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+% Set default figure placement to htbp
+\makeatletter
+\def\fps@figure{htbp}
+\makeatother
+
 $if(csl-refs)$
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
@@ -57,7 +72,8 @@ $if(csl-refs)$
 \newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
-
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \title{$title$}
 
 


### PR DESCRIPTION
Fixes issues when exporting with the neurips template (it was missing the graphicx package). 

Also found that the neurips template referred to `academic.tex` rather than `neurips.tex` so I fixed it.