### PR TITLE
Resolve variables for "after export" command

### DIFF
--- a/src/exporto0o.ts
+++ b/src/exporto0o.ts
@@ -190,7 +190,8 @@ export async function exportToOo(
         await ct.remote.shell.openPath(actualOutputPath);
       }
       if (setting.type === 'pandoc' && setting.runCommand === true && setting.command) {
-        await exec(setting.command);
+        const extCmd = renderTemplate(setting.command, variables);
+        await exec(extCmd, { cwd: variables.currentDir, env });
       }
       // success
       onSuccess && onSuccess();


### PR DESCRIPTION
Replace the plugin-specific and environment variables in the "After Export" command with their values to ensure consistency with the main command.

This enables more complex post-processing of the output. The current version only accepts absolute paths and it can't access the name of the original input file, severely limiting its applicability.

In my case, for example, I needed to extract the bibliography for a `.tex` file in the same directory as the exported file and with a specific name, using a second invocation of `pandoc`.