### PR TITLE
Changed to metadataCache instead of processFrontMatter

### DIFF
--- a/src/exporto0o.ts
+++ b/src/exporto0o.ts
@@ -27,7 +27,7 @@ export async function exportToOo(
     app: {
       vault: { adapter, config: obsidianConfig },
       loadProgress: progress,
-      fileManager,
+      metadataCache,
     },
   } = plugin;
 
@@ -76,7 +76,7 @@ export async function exportToOo(
 
   let frontMatter: unknown = null;
   try {
-    await fileManager.processFrontMatter(currentFile, fm => frontMatter = fm);
+	  frontMatter = metadataCache.getCache(currentFile.path).frontmatter;
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
Changed to metadataCache instead of processFrontMatter to retrieve the metadata of the current file.

processFrontMatter not only reads the metadata, but also modifies the file. YAML comments are removed in the process.

metadataCache does not have this problem. I have been running this change for a few weeks now and it doesn't seem to be causing any problems.

See also Issue #97

If further changes to the pull request are required, please contact me.