### PR TITLE
Set input file as first argument rather than last

### DIFF
--- a/src/exporto0o.ts
+++ b/src/exporto0o.ts
@@ -175,7 +175,7 @@ export async function exportToOo(
 
   const cmdTpl =
     setting.type === 'pandoc'
-      ? `${pandocPath} ${setting.arguments ?? ''} ${setting.customArguments ?? ''} "\${currentPath}"`
+      ? `${pandocPath} "\${currentPath}" ${setting.arguments ?? ''} ${setting.customArguments ?? ''}`
       : setting.command;
 
   const cmd = renderTemplate(cmdTpl, variables);


### PR DESCRIPTION
Rearranged the final command template as discussed here: https://github.com/mokeyish/obsidian-enhancing-export/issues/166, putting the input file first to avoid potential issues.