### PR TITLE
Fix attachmentFolderPath and remove unncessary command template arguments

### DIFF
--- a/src/export_templates.ts
+++ b/src/export_templates.ts
@@ -44,7 +44,7 @@ export default {
     name: 'TextBundle',
     type: 'pandoc',
     arguments:
-      '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" --lua-filter="${luaDir}/markdown.lua" -V media_dir="${outputDir}/${outputFileName}.textbundle/assets" -o "${outputDir}/${outputFileName}.textbundle/text.md" -t commonmark_x-attributes',
+      '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" --lua-filter="${luaDir}/markdown.lua" -V media_dir="${outputDir}/${outputFileName}.textbundle/assets" -s -o "${outputDir}/${outputFileName}.textbundle/text.md" -t commonmark_x-attributes',
     extension: '.md',
   },
   'Typst': {
@@ -58,7 +58,7 @@ export default {
     name: 'PDF',
     type: 'pandoc',
     arguments:
-      '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" --lua-filter="${luaDir}/pdf.lua" ${ options.textemplate ? `--resource-path="${pluginDir}/textemplate" --template="${options.textemplate}"` : ` ` } -s -o "${outputPath}" -t pdf',
+      '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" --lua-filter="${luaDir}/pdf.lua" ${ options.textemplate ? `--resource-path="${pluginDir}/textemplate" --template="${options.textemplate}"` : ` ` } -o "${outputPath}" -t pdf',
     customArguments: '--pdf-engine=pdflatex',
     optionsMeta: {
       'textemplate': 'preset:textemplate', // reference from `PresetOptionsMeta` in `src/settings.ts`

--- a/src/export_templates.ts
+++ b/src/export_templates.ts
@@ -44,7 +44,7 @@ export default {
     name: 'TextBundle',
     type: 'pandoc',
     arguments:
-      '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" --lua-filter="${luaDir}/markdown.lua" -V media_dir="${outputDir}/${outputFileName}.textbundle/assets" -s -o "${outputDir}/${outputFileName}.textbundle/text.md" -t commonmark_x-attributes',
+      '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" --lua-filter="${luaDir}/markdown.lua" -V media_dir="${outputDir}/${outputFileName}.textbundle/assets" -o "${outputDir}/${outputFileName}.textbundle/text.md" -t commonmark_x-attributes',
     extension: '.md',
   },
   'Typst': {
@@ -68,13 +68,13 @@ export default {
   'Word (.docx)': {
     name: 'Word (.docx)',
     type: 'pandoc',
-    arguments: '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" -s -o "${outputPath}" -t docx',
+    arguments: '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" -o "${outputPath}" -t docx',
     extension: '.docx',
   },
   'OpenOffice': {
     name: 'OpenOffice',
     type: 'pandoc',
-    arguments: '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" -s -o "${outputPath}" -t odt',
+    arguments: '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" -o "${outputPath}" -t odt',
     extension: '.odt',
   },
   'RTF': {
@@ -86,7 +86,7 @@ export default {
   'Epub': {
     name: 'Epub',
     type: 'pandoc',
-    arguments: '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" -s -o "${outputPath}" -t epub',
+    arguments: '-f ${fromFormat} --resource-path="${currentDir}" --resource-path="${attachmentFolderPath}" -o "${outputPath}" -t epub',
     extension: '.epub',
   },
   'Latex': {

--- a/src/exporto0o.ts
+++ b/src/exporto0o.ts
@@ -74,6 +74,8 @@ export async function exportToOo(
     attachmentFolderPath = vaultDir;
   } else if (attachmentFolderPath.startsWith('.')) {
     attachmentFolderPath = path.join(currentDir, attachmentFolderPath.substring(1));
+  } else {
+    attachmentFolderPath = path.join(vaultDir, attachmentFolderPath);
   }
 
   let frontMatter: unknown = null;


### PR DESCRIPTION
Previously, attachmentFolderPath would just return the attachment folder name. This was only sufficient when executing Pandoc from notes in the vault root (I think). In most scenarios, Pandoc would fail to find the images (see: https://github.com/mokeyish/obsidian-enhancing-export/issues/74#issuecomment-1704426809). 

Therefore, this PR makes it so that `vaultDir` and `attachmentFolderPath` are joined, making an absolute attachment folder path that will work in any scenario.

Furthermore, I also included some cleanup of the default commands, removing `-s` where it was not needed, as it is already included by default in these output formats. See: https://pandoc.org/MANUAL.html#option--standalone

I tested the changes by building the plugin locally, and running a PDF export with the default command on a note with an image included. I confirmed that the command logged in the console contained the correct absolute attachment path, and of course that the export worked as expected.