### PR TITLE
Adds variable containing embedDirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You can use `${variables}` in custom export command, their values are:
 | `${currentFileFullName}`  | Filename with extension of currently edited file. It will be `readme.md` in above case. |
 | `${vaultDir}`             | The obsidian current vaultDir.                               |
 | `${attachmentFolderPath}` | The `attachmentFolderPath` of Obsidian.                      |
+| `${embedDirs}` 			| String containing directories of embedded files for use with --resource-path argument e.g. --resource-path=`${embedDirs}`    |
 | Others variables          | You can use `keyword: value` in [YAML Front Matter](https://jekyllrb.com/docs/front-matter/), then use `${metadata.keyword}` |
 
 ## Related resources

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -33,6 +33,7 @@ export interface Variables extends Record<string, unknown> {
   // lastMod: new Date(currentFile.stat.mtime),
   // now: new Date()
   metadata?: unknown;
+  embedDirs: string;
   options?: unknown;
   env?: Record<string, string>;
 }


### PR DESCRIPTION
Useful for automatically adding embedded file directories to the --resource-path argument, so you don't have to change it manually each time if your resources are scattered across multiple locations.