### PR TITLE
fix(math envs): Only change environments not allowed in math.

### DIFF
--- a/lua/pdf.lua
+++ b/lua/pdf.lua
@@ -1,12 +1,50 @@
-
-return {
-    {
-        Math = function (elem)
-            if elem.text:find("^%s*\\begin{") ~= nil then
-                return pandoc.RawInline('tex', elem.text)
-            else
-                return elem
-            end
-        end,
-    }
+-- minimum supported version for full environment
+-- support is 3.8.unkown yet to be released but probably 3
+local environment_fully_supported_version = pandoc.types.Version('3.8.3')
+local environment_partially_supported_version = pandoc.types.Version('3.8.0')
+local is_partially_supported = PANDOC_VERSION >= environment_partially_supported_version
+local problamatic_environments = {
+    displaymath = true,
+    math = true,
+    equation = true,
+    ["equation*"] = true,
+    gather = true,
+    ["gather*"] = true,
+    multline = true,
+    ["multline*"] = true,
+    eqnarray = true,
+    ["eqnarray*"] = true,
+    align = true,
+    ["align*"] = true,
+    alignat = true,
+    ["alignat*"] = true,
+    flalign = true,
+    ["flalign*"] = true,
 }
+if is_partially_supported then
+    return {
+        {
+            Math = function(elem)
+                if elem.text:find("^%s*\\begin{") ~= nil then
+                    local replacement = pandoc.text:gsub(elem.text, "^%s*\\begin{(.-)}", "\\begin{%1}"):gsub("\\end{(.-)}%s*$", "\\end{%1}")
+                    return pandoc.Math(replacement, elem.mathtype)
+                else
+                    return elem
+                end
+            end,
+        }
+    }
+elseif not environment_fully_supported_version then
+    return {
+        {
+            Math = function(elem)
+                local result = elem.text:match("^%s*\\begin{(%a+%*?)}")
+                if result ~= nil and problamatic_environments[result] ~= nil then
+                    return pandoc.RawInline('tex', elem.text)
+                else
+                    return elem
+                end
+            end,
+        }
+    }
+end


### PR DESCRIPTION
Partially fixes #298.
Environments like `align` are not allowedi n latex math environments
and pandoc doesn't take those out of the math environments thus a filter was made to partially fix that.
But that filter captures too much and shouldn't capture environments like matrix and aligned and more.
Thus for <3.8 only those environments are fixed
for 3.8-3.8.2.x space is deleted because of https://github.com/jgm/pandoc/issues/11266.
And for >=3.8.3 that fix should be included thus no extra parsing is needed.
Note 3.8.3 hasn't actually been released as of writing. The fix has been integrated, but yet to have been released. Im assuming it will come out in 3.8.3 but you can also leave the pr open till that actually happens