### PR TITLE
Fix: Add null check for embeds to prevent crash when file has no internal links

### DIFF
--- a/src/exporto0o.ts
+++ b/src/exporto0o.ts
@@ -84,7 +84,7 @@ export async function exportToOo(
   } catch (e) {
     console.error(e);
   }
-  
+
   let embedArray: unknown = null;
   try {
     embedArray = metadataCache.getCache(currentFile.path).embeds;
@@ -92,14 +92,14 @@ export async function exportToOo(
     console.error(e);
   }
   let targetDirArray: string[] = [];
-  for (const embed of embedArray) {
-	const linkPath = embed.link;
-	const targetFile = metadataCache.getFirstLinkpathDest(linkPath, currentFile.path);
-	if (targetFile instanceof TFile) {
+  for (const embed of (embedArray || [])) {
+    const linkPath = embed.link;
+    const targetFile = metadataCache.getFirstLinkpathDest(linkPath, currentFile.path);
+    if (targetFile instanceof TFile) {
       targetDirArray.push(path.join(vaultDir, path.dirname(targetFile.path)));
-	} else if (targetFile === null) {
-	  console.warn(`Could not resolve embedded file: ${linkPath}`);
-	}
+    } else if (targetFile === null) {
+      console.warn(`Could not resolve embedded file: ${linkPath}`);
+    }
   }
   targetDirArray = [...new Set(targetDirArray)];
   const embedDirs = targetDirArray.join(path.delimiter);


### PR DESCRIPTION
## 问题描述

当 Markdown 文件中没有内部链接（embeds）时，插件在尝试遍历 `embedArray` 时会因为空指针（null）导致崩溃，使插件无响应。

## 根本原因

在 `src/exporto0o.ts` 第95行，代码直接遍历 `embedArray` 而没有检查其是否为 null：

```typescript
for (const embed of embedArray) {
```

当文件没有任何嵌入式链接时，`metadataCache.getCache(currentFile.path).embeds` 返回 `null`，导致运行时错误。

## 解决方案

添加空指针保护，使用 `|| []` 确保即使 `embedArray` 为 null 也能安全遍历：

```typescript
for (const embed of (embedArray || [])) {
```

## 测试

- ✅ 在没有内部链接的 Markdown 文件上测试 - 插件正常工作
- ✅ 在有内部链接的文件上测试 - 功能未受影响
- ✅ 在有多个嵌入链接的文件上测试 - 正常处理

## 影响范围

- 修改最小化，仅添加空指针检查
- 不影响现有功能
- 向后兼容

## 相关 Issues

此修复解决了用户在导出无链接文件时遇到的崩溃问题。